### PR TITLE
fix host discovery

### DIFF
--- a/ansible/roles/dataplane/tasks/main.yml
+++ b/ansible/roles/dataplane/tasks/main.yml
@@ -13,7 +13,7 @@
 
 - name: Wait for dataplane deployment to finish
   shell: |
-    oc wait osdpns openstack-edpm -n openstack --for condition=Ready --timeout=40m
+    oc wait osdpd openstack-edpm -n openstack --for condition=Ready --timeout=40m
 
 - name: Run nova-manage cell_v2 discover_hosts
   shell: |


### PR DESCRIPTION
sometime host discovery is returning the empty list, since we are doing the discovery after the nodeset is ready. changing this to do after the deployment is ready.