### PR TITLE
Add validate_certs=false to resolve SSL issue during installation

### DIFF
--- a/ansible/roles/bootstrap/tasks/includes/download_ocp_inventory.yml
+++ b/ansible/roles/bootstrap/tasks/includes/download_ocp_inventory.yml
@@ -23,6 +23,7 @@
     url: "https://wiki.scalelab.redhat.com/instack/{{ cloud }}_ocpinventory.json"
     return_content: true
   register: ocpinventory_scale
+  validate_certs: false
   when:
     - lab == 'scalelab'
     - not (local_inventory_file.stat.exists | default(false))
@@ -32,6 +33,7 @@
   uri:
     url: "https://wiki.rdu3.labs.perfscale.redhat.com/instack/{{ cloud }}_ocpinventory.json"
     return_content: true
+    validate_certs: false
   register: ocpinventory_alias
   when:
     - lab == 'performancelab'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved TLS certificate validation errors during OCP inventory downloads from both scalelab and performancelab environments. The system now successfully retrieves inventory data without certificate validation blocking the process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/redhat-performance/JetBrew/pull/37)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->