### PR TITLE
fix the external net creation failure

### DIFF
--- a/ansible/roles/post/tasks/main.yml
+++ b/ansible/roles/post/tasks/main.yml
@@ -3,10 +3,10 @@
   vars:
     vlan_interface: "{{ iface_2 }}.{{ external_network_vlan_id }}"
   shell: |
-    ip link add link {{ iface_2 }} name {{ vlan_interface }} type vlan id {{ external_network_vlan_id }}
+    ip link show {{ vlan_interface }} > /dev/null 2>&1 || ip link add link {{ iface_2 }} name {{ vlan_interface }} type vlan id {{ external_network_vlan_id }}
     ip link set dev {{ iface_2 }} up
     ip link set dev {{ vlan_interface }} up
-    ip a a {{ external_net_gateway }}/{{ external_net_cidr.split('/')[1] }} dev {{ vlan_interface }}
+    ip addr show dev {{ vlan_interface }} | grep -q "{{ external_net_gateway }}/{{ external_net_cidr.split('/')[1] }}" || ip a a {{ external_net_gateway }}/{{ external_net_cidr.split('/')[1] }} dev {{ vlan_interface }}
   become: true
 
 - name: Create external network


### PR DESCRIPTION
if the interface is already created with same ip it failing on the subsequent runs. now adding a check before creating the interface

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VLAN interface configuration reliability by adding existence checks before creating interfaces and assigning IP addresses. The setup process is now idempotent and can be safely re-run without errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->